### PR TITLE
Fixes linefeed/filedecoding on Linux.

### DIFF
--- a/FileWriter.py
+++ b/FileWriter.py
@@ -23,4 +23,4 @@ class FileWriter:
 
     def writeFile(self, input):
         with open(self.path, 'w') as file:
-            file.write(str(input))
+            file.write(input.decode())


### PR DESCRIPTION
On linux the `str(input)` call is resulting in a string b'<contentgoeshere>' making the `.csv` parse incorrectly.  This small change fixes that.